### PR TITLE
Proposals for a better overview in the terminal (#283)

### DIFF
--- a/vunit/simulator_interface.py
+++ b/vunit/simulator_interface.py
@@ -169,7 +169,9 @@ class SimulatorInterface(object):
                 print("Skipping %s due to failed dependencies" % simplify_path(source_file.name))
                 continue
 
-            print('Compiling %s into %s ...' % (simplify_path(source_file.name), source_file.library.name))
+            #print('Compiling %s into %s ...' % (simplify_path(source_file.name), source_file.library.name))   # it is clearer if we all in columns
+            print('Compiling  into %-20s %s ' % ( source_file.library.name, simplify_path(source_file.name)))  # ASICNET-changed
+			
             try:
                 command = None
                 command = self.compile_source_file_command(source_file)

--- a/vunit/test_runner.py
+++ b/vunit/test_runner.py
@@ -30,7 +30,7 @@ class TestRunner(object):  # pylint: disable=too-many-instance-attributes
     Administer the execution of a list of test suites
     """
     def __init__(self, report, output_path, verbose=False, num_threads=1,
-                 dont_catch_exceptions=False):
+				 dont_catch_exceptions=False, quiet=False ):  # ASICNET-Added quiet
         self._lock = threading.Lock()
         self._local = threading.local()
         self._report = report
@@ -40,7 +40,7 @@ class TestRunner(object):  # pylint: disable=too-many-instance-attributes
         self._stdout = sys.stdout
         self._stderr = sys.stderr
         self._dont_catch_exceptions = dont_catch_exceptions
-
+        self._quiet = quiet # ASICNET-Added
     def run(self, test_suites):
         """
         Run a list of test suites
@@ -105,7 +105,8 @@ class TestRunner(object):  # pylint: disable=too-many-instance-attributes
         Run worker thread
         """
         self._local.output = self._stdout
-
+        print(); # ASICNET-Added a empty line for clearer overview
+        
         while True:
             test_suite = None
             try:
@@ -137,6 +138,8 @@ class TestRunner(object):  # pylint: disable=too-many-instance-attributes
         """
         output_path = create_output_path(self._output_path, test_suite.name)
         output_file_name = join(output_path, "output.txt")
+        if self._quiet:                                # ASICNET-Added
+            print("Logfile: %s" % output_file_name)       # It can be of interest to load the file in a editor
         start_time = ostools.get_time()
 
         try:
@@ -174,7 +177,7 @@ class TestRunner(object):  # pylint: disable=too-many-instance-attributes
         any_not_passed = any(value != PASSED for value in results.values())
 
         with self._lock:  # pylint: disable=not-context-manager
-            if (not write_stdout) and (any_not_passed or self._verbose):
+            if (not write_stdout) and (any_not_passed or self._verbose) and (not self._quiet):  # ASICNET-Added quiet. to much information in the terminal
                 self._print_output(output_file_name)
             self._add_results(test_suite, results, start_time, num_tests, output_file_name)
 

--- a/vunit/ui.py
+++ b/vunit/ui.py
@@ -845,6 +845,7 @@ avoid location preprocessing of other functions sharing name with a VUnit log or
         runner = TestRunner(report,
                             join(self._output_path, "test_output"),
                             verbose=self._args.verbose,
+							quiet=self._args.quiet, # ASICNET-Added
                             num_threads=self._args.num_threads,
                             dont_catch_exceptions=self._args.dont_catch_exceptions)
         runner.run(test_cases)

--- a/vunit/vunit_cli.py
+++ b/vunit/vunit_cli.py
@@ -134,6 +134,11 @@ def _create_argument_parser(description=None, for_documentation=False):
                         default=False,
                         help='Print test output immediately and not only when failure')
 
+# ASICNET-Added --++
+    parser.add_argument('-q', '--quiet', action="store_true",
+                        default=False,
+                        help='Print test output only in output.txt and the path to output.txt in the terminal')
+# ++--
     parser.add_argument('--no-color', action='store_true',
                         default=False,
                         help='Do not color output')


### PR DESCRIPTION
Hi
I have two proposals for a better overview in the terminal. Maybe it is interesting.

In the compile phase the output is not divided in columns.
I changed this to
Compiling into 
Compiling into vunit_lib ..........\VUnit\vunit\vunit\vhdl\path\src\path.vhd
Compiling into osvvm ..........\VUnit\vunit\vunit\vhdl\osvvm\VendorCovApiPkg.vhd

Added the option --log-only
If a lot of test are failed I have to much output in the terminal or command window. That is unclear.
The option suppresses the output and print instead the path to the output.txt.